### PR TITLE
Fix `params` input type

### DIFF
--- a/src/livechat-widget.component.ts
+++ b/src/livechat-widget.component.ts
@@ -11,7 +11,7 @@ export class LivechatWidgetComponent implements OnInit {
   @Input() licenseId: number;
   @Input() group: number;
   @Input() chatBetweenGroups: boolean;
-  @Input() params: { name: string, value: any };
+  @Input() params: Array<{ name: string, value: any }>;
   @Input() visitor: { name: string, email: string, };
   @Input() gaVersion: string;
   @Output() public onChatLoaded = new Subject<LiveChatWidgetApiModel>();


### PR DESCRIPTION
According to [this](https://www.livechat.com/help/custom-variables-configuration/), params should be an array, which makes sense; why would you only accept a single name/value pair?